### PR TITLE
BUGFIX: many_many through should allow subclasses

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -1171,7 +1171,7 @@ class DataObjectSchema
         }
 
         // Validate bad types on parent relation
-        if ($key === 'from' && $relationClass !== $parentClass) {
+        if ($key === 'from' && $relationClass !== $parentClass && !is_subclass_of($parentClass, $relationClass)) {
             throw new InvalidArgumentException(
                 "many_many through relation {$parentClass}.{$component} {$key} references a field name "
                 . "{$joinClass}::{$relation} of type {$relationClass}; {$parentClass} expected"


### PR DESCRIPTION
```php
class HomePage extends Page
{
    private static $many_many = [
        'HeroImages' => [
            'through' => PageImageLink::class,
            'from' => 'Page',
            'to' => 'Image',
        ]
    ];

}
```

```php
class PageImageLink extends DataObject
{
    private static $has_one = [
        'Page' => SiteTree::class,
        'Image' => Image::class,
    ];
}

This fails because the linking object's relation class doesn't exactly match the owner. Sharing the linking objects across various entries in the ancestry should be a supported use case.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
